### PR TITLE
Anticipates the use of a Set data type

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -103,7 +103,7 @@ describe('toBeSorted', () => {
     });
   });
 
-  describe('works with the sets', () => {
+  describe('flat sets', () => {
     const unsortedSet = new Set([1, 8, 3, 207]);
     const ascendingSet = new Set([5, 8, 24, 300]);
     it('fail - an unsorted set no longer passes by default', () => {

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -103,6 +103,18 @@ describe('toBeSorted', () => {
     });
   });
 
+  describe('works with the sets', () => {
+    const unsortedSet = new Set([1, 8, 3, 207]);
+    const ascendingSet = new Set([5, 8, 24, 300]);
+    it('fail - an unsorted set no longer passes by default', () => {
+      expect(toBeSorted(unsortedSet).pass).toBe(false);
+    });
+
+    it('pass - set with ascending numbers', () => {
+      expect(toBeSorted(ascendingSet).pass).toBe(true);
+    });
+  });
+
   describe('toBeSortedBy', () => {
     const ascendingObjs = [{ num: 1 }, { num: 2 }, { num: 3 }];
     const descendingObjs = [{ num: 3 }, { num: 2 }, { num: 1 }];

--- a/src/sorted.js
+++ b/src/sorted.js
@@ -9,6 +9,8 @@ const defaultCompare = (a, b) => {
 };
 
 exports.toBeSorted = (received, options = {}) => {
+  const iterable = [...received];
+
   const {
     descending = false,
     key,
@@ -17,16 +19,16 @@ exports.toBeSorted = (received, options = {}) => {
     compare = defaultCompare,
   } = options;
   const descMult = descending ? -1 : 1;
-  const arrayMsg = key ? `Array(${received.length})` : `[${received}]`;
+  const arrayMsg = key ? `Array(${iterable.length})` : `[${iterable}]`;
   const orderMsg = descending ? 'descending' : 'ascending';
   let keyMsg = key ? `by ${key} ` : '';
 
   let pass = true;
 
   // we're accessing the next element where we would compare with undefined.
-  for (let i = 0; i < received.length - 1; i++) {
-    let ele = received[i];
-    let nextEle = received[i + 1];
+  for (let i = 0; i < iterable.length - 1; i++) {
+    let ele = iterable[i];
+    let nextEle = iterable[i + 1];
     if (key) {
       if (strict && !(key in ele)) {
         pass = false;


### PR DESCRIPTION
Sets would pass by default, a quick spread of the received iterable now allows for a set to be tested without the end-user having to manually spread them into an array within their tests.